### PR TITLE
Create CODEOWNERS, requiring review from either Jack or Alex

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require approval from Jack or Alex
+* @acmcarther @jalexanderqed


### PR DESCRIPTION
This needs a corresponding setting to be enabled in `Settings`, which I'll toggle after this is submitted.