### PR TITLE
Use `mvn package appengine:deploy` instead of gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
 steps:
-- name: "gcr.io/cloud-builders/gcloud"
-  args: ["app", "deploy"]
+- name: "gcr.io/cloud-builders/mvn"
+  args: ["package", "appengine:deploy"]
 timeout: "1600s"


### PR DESCRIPTION
This PR updates the cloudbuild.yaml to use maven instead.

Cite:
- https://groups.google.com/d/msg/google-appengine/arpnkSixFlM/IR5ATrvvBAAJ
- https://cloud.google.com/appengine/docs/standard/java/tools/uploadinganapp#using_maven_recommended
- https://cloud.google.com/artifact-registry/docs/configure-cloud-build#maven