### PR TITLE
Sort returned Interviews 

### DIFF
--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -73,7 +73,7 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
     Query query =
         new Query("ScheduledInterview")
             .setFilter(compositeFilter)
-            .addSort("startTime", SortDirection.DESCENDING);
+            .addSort("startTime", SortDirection.ASCENDING);
     PreparedQuery results = datastore.prepare(query);
     List<ScheduledInterview> relevantInterviews = new ArrayList<>();
 

--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -78,7 +78,7 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
     return relevantInterviews;
   }
 
-  /** Creates a ScheduledInterview Entity. */
+  /** Creates a ScheduledInterview Entity and stores it in Datastore. */
   @Override
   public void create(ScheduledInterview scheduledInterview) {
     datastore.put(scheduledInterviewToEntity(scheduledInterview));

--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -81,12 +81,8 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
   /** Creates a ScheduledInterview Entity. */
   @Override
   public void create(ScheduledInterview scheduledInterview) {
-    datastore.put(scheduledInterviewToEntity(scheduledInterview)); 
+    datastore.put(scheduledInterviewToEntity(scheduledInterview));
   }
-
-  }
-
-
 
   /** Updates an entity in datastore. */
   @Override
@@ -113,6 +109,7 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
         (String) scheduledInterviewEntity.getProperty("interviewee"));
   }
 
+  /** Creates a scheduledInterview Entity from a scheduledInterview object. */
   public Entity scheduledInterviewToEntity(ScheduledInterview scheduledInterview) {
     Entity scheduledInterviewEntity = new Entity("ScheduledInterview");
     scheduledInterviewEntity.setProperty(
@@ -120,5 +117,6 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
     scheduledInterviewEntity.setProperty("endTime", scheduledInterview.when().end().toEpochMilli());
     scheduledInterviewEntity.setProperty("interviewer", scheduledInterview.interviewerEmail());
     scheduledInterviewEntity.setProperty("interviewee", scheduledInterview.intervieweeEmail());
+    return scheduledInterviewEntity;
   }
 }

--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -26,7 +26,6 @@ import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Query.SortDirection;
-
 import java.time.Instant;
 import java.util.Optional;
 import java.util.ArrayList;
@@ -60,7 +59,7 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
 
   /**
    * Retrieves all scheduledInterview entities from Datastore that involve a particular user and
-   * returns them as a list of ScheduledInterview objects.
+   * returns them as a list of ScheduledInterview objects in the order in which they occur.
    */
   @Override
   public List<ScheduledInterview> getForPerson(String email) {

--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -25,6 +25,8 @@ import com.google.appengine.api.datastore.Query.CompositeFilter;
 import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
 import java.time.Instant;
 import java.util.Optional;
 import java.util.ArrayList;
@@ -68,7 +70,10 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
         new FilterPredicate("interviewee", FilterOperator.EQUAL, email);
     CompositeFilter compositeFilter =
         CompositeFilterOperator.or(interviewerFilter, intervieweeFilter);
-    Query query = new Query("ScheduledInterview").setFilter(compositeFilter);
+    Query query =
+        new Query("ScheduledInterview")
+            .setFilter(compositeFilter)
+            .addSort("startTime", SortDirection.DESCENDING);
     PreparedQuery results = datastore.prepare(query);
     List<ScheduledInterview> relevantInterviews = new ArrayList<>();
 

--- a/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
+++ b/src/main/java/com/google/sps/data/DatastoreScheduledInterviewDao.java
@@ -81,14 +81,12 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
   /** Creates a ScheduledInterview Entity. */
   @Override
   public void create(ScheduledInterview scheduledInterview) {
-    Entity scheduledInterviewEntity = new Entity("ScheduledInterview");
-    scheduledInterviewEntity.setProperty(
-        "startTime", scheduledInterview.when().start().toEpochMilli());
-    scheduledInterviewEntity.setProperty("endTime", scheduledInterview.when().end().toEpochMilli());
-    scheduledInterviewEntity.setProperty("interviewer", scheduledInterview.interviewerEmail());
-    scheduledInterviewEntity.setProperty("interviewee", scheduledInterview.intervieweeEmail());
-    datastore.put(scheduledInterviewEntity);
+    datastore.put(scheduledInterviewToEntity(scheduledInterview)); 
   }
+
+  }
+
+
 
   /** Updates an entity in datastore. */
   @Override
@@ -107,11 +105,20 @@ public class DatastoreScheduledInterviewDao implements ScheduledInterviewDao {
   /** Creates a ScheduledInterview object from a datastore entity. */
   public ScheduledInterview entityToScheduledInterview(Entity scheduledInterviewEntity) {
     return ScheduledInterview.create(
-        Long.valueOf(scheduledInterviewEntity.getKey().toString()),
+        scheduledInterviewEntity.getKey().getId(),
         new TimeRange(
             Instant.ofEpochMilli((long) scheduledInterviewEntity.getProperty("startTime")),
             Instant.ofEpochMilli((long) scheduledInterviewEntity.getProperty("endTime"))),
         (String) scheduledInterviewEntity.getProperty("interviewer"),
         (String) scheduledInterviewEntity.getProperty("interviewee"));
+  }
+
+  public Entity scheduledInterviewToEntity(ScheduledInterview scheduledInterview) {
+    Entity scheduledInterviewEntity = new Entity("ScheduledInterview");
+    scheduledInterviewEntity.setProperty(
+        "startTime", scheduledInterview.when().start().toEpochMilli());
+    scheduledInterviewEntity.setProperty("endTime", scheduledInterview.when().end().toEpochMilli());
+    scheduledInterviewEntity.setProperty("interviewer", scheduledInterview.interviewerEmail());
+    scheduledInterviewEntity.setProperty("interviewee", scheduledInterview.intervieweeEmail());
   }
 }


### PR DESCRIPTION
Modified DatastoreScheduledInterviewDao so that the serialization and deserialization of the data is more explicit and the scheduledInterview objects returned from the getForPerson() method are in the order in which they occur. 